### PR TITLE
16.0 gio fixes

### DIFF
--- a/website_calendar_event/controllers/main.py
+++ b/website_calendar_event/controllers/main.py
@@ -5,6 +5,7 @@ from odoo import http, _, fields
 from odoo.http import request
 
 from odoo.addons.website_calendar_ce.controllers.main import WebsiteCalendar
+#from odoo.exceptions import AccessError
 
 
 _logger = logging.getLogger(__name__)
@@ -23,7 +24,12 @@ class ExtendedWebsiteCalendar(WebsiteCalendar):
         customer_id = None
         if related_users:
             customer_id = related_users[0][1]
-
+        # creating the task will cause error if there is no customer_id. 
+        # this will happen when the person Booking is the same as the Employee connected
+        # to the booking , in that case we set the correct customer.
+        # become the user_id of project task. so the default for customer_id is set to  
+        customer_id = [x for x in data.get('partner_ids', []) if x[1] == Employee.user_partner_id.id]
+ 
         data = {
                 'name': event.name,
                 'project_id': booking_type.related_project_id.id,

--- a/website_calendar_event/controllers/main.py
+++ b/website_calendar_event/controllers/main.py
@@ -5,7 +5,6 @@ from odoo import http, _, fields
 from odoo.http import request
 
 from odoo.addons.website_calendar_ce.controllers.main import WebsiteCalendar
-#from odoo.exceptions import AccessError
 
 
 _logger = logging.getLogger(__name__)
@@ -24,16 +23,10 @@ class ExtendedWebsiteCalendar(WebsiteCalendar):
         customer_id = None
         if related_users:
             customer_id = related_users[0][1]
-        # creating the task will cause error if there is no customer_id. 
-        # this will happen when the person Booking is the same as the Employee connected
-        # to the booking , in that case we set the correct customer.
-        # become the user_id of project task. so the default for customer_id is set to  
-        customer_id = [x for x in data.get('partner_ids', []) if x[1] == Employee.user_partner_id.id]
- 
         data = {
                 'name': event.name,
                 'project_id': booking_type.related_project_id.id,
-                'user_id': Employee.user_id.id,
+                'user_ids': [Employee.user_id.id],
                 'recurring_task': False,
                 'description': data.get('description').replace("\n", "<br/>"),
                 'partner_id': customer_id,


### PR DESCRIPTION
Key user_id does not exist in  project.task, replaced by user_ids.
If left as-is , confirming a booking will cause error:
```

File "/home/ubuntu/odoo/custom/src/odoo/odoo/addons/base/models/ir_fields.py", line 670, in create
recs = super().create(vals_list)
File "<decorator-gen-15>", line 2, in create
File "/home/ubuntu/odoo/custom/src/odoo/odoo/api.py", line 415, in _model_create_multi
return create(self, arg)
File "/home/ubuntu/odoo/custom/src/odoo/odoo/models.py", line 3931, in create
raise ValueError("Invalid field %r on model %r" % (key, self._name))
ValueError: Invalid field 'user_id' on model 'project.task'
```